### PR TITLE
Add missing dependencys to build on alpine 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,8 @@ RUN set -xe \
                           python3         \
                           python3-dev     \
                           py-pip          \
+                          rust            \
+                          cargo           \
     && python3 -m pip install appdirs   \
                               cssselect \
                               keyring   \


### PR DESCRIPTION
There is this problem when trying to build your Dockerfile that is a known issue and requires rust compiler being installed.

#5 45.47   running build_rust
#5 45.47
#5 45.47       =============================DEBUG ASSISTANCE=============================
#5 45.47       If you are seeing a compilation error please try the following steps to
#5 45.47       successfully install cryptography:
#5 45.47       1) Upgrade to the latest pip and try again. This will fix errors for most
#5 45.47          users. See: https://pip.pypa.io/en/stable/installing/#upgrading-pip
#5 45.47       2) Read https://cryptography.io/en/latest/installation.html for specific
#5 45.47          instructions for your platform.
#5 45.47       3) Check our frequently asked questions for more information:
#5 45.47          https://cryptography.io/en/latest/faq.html
#5 45.47       4) Ensure you have a recent Rust toolchain installed:
#5 45.47          https://cryptography.io/en/latest/installation.html#rust
#5 45.47       5) If you are experiencing issues with Rust for *this release only* you may
#5 45.47          set the environment variable `CRYPTOGRAPHY_DONT_BUILD_RUST=1`.
#5 45.47       =============================DEBUG ASSISTANCE=============================
#5 45.47
#5 45.47   error: can't find Rust compiler