### PR TITLE
Provide html2text

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN set -xe \
                               requests  \
                               chump     \
                               urlwatch  \
+                              html2text \
     && apk del build-base  \
                libffi-dev  \
                libxml2-dev \


### PR DESCRIPTION
I'm currently migrating the many microservices I have floating around on my server into individual docker containers and found your Dockerfile for `urlwatch`. What I'm missing in your container is `(py)html2text` which I'm suing in many of my (over 30) watch filters. I found it gives superior results to using the standard `html2text` plugin.

Example:

``` yaml
name: "Gemeinde Grafschaft: Aktuelles"
url: "https://www.gemeinde-grafschaft.de/aktuelles/2022/"
filter:
  - css: div.xhtmlcomponent:nth-child(1)
  - html2text: pyhtml2text
  - strip
```