### PR TITLE
Use multi-stage build to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM alpine
+FROM alpine as builder
 
-ENV APP_USER urlwatch
+ENV PATH="/opt/venv/bin:${PATH}"
 
 RUN set -xe \
     && apk add --no-cache ca-certificates \
@@ -16,6 +16,7 @@ RUN set -xe \
                           python3-dev     \
                           py-pip          \
                           rust            \
+    && python3 -m venv --copies /opt/venv \
     && python3 -m pip install appdirs   \
                               chump     \
                               cssselect \
@@ -25,13 +26,14 @@ RUN set -xe \
                               minidb    \
                               pyyaml    \
                               requests  \
-                              urlwatch  \
-    && apk del build-base  \
-               libffi-dev  \
-               libxml2-dev \
-               libxslt-dev \
-               openssl-dev \
-               python3-dev
+                              urlwatch
+
+FROM python:3.10-alpine as deploy
+
+ENV APP_USER urlwatch
+
+COPY --from=builder /opt/venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
 
 RUN addgroup $APP_USER
 RUN adduser -D -G $APP_USER $APP_USER


### PR DESCRIPTION
I noticed that the final image is **>1GB**! (Despite starting with a 5 MB alpine base image).

Reason is, that for a lot of PyPI packages there are no pre-built `musl` binaries (wheels) but they need to be compiled from source requiring a lot of tools. This blows up the final images. Read more [here](https://pythonspeed.com/articles/alpine-docker-python/).

One way to reduce size is to use a multi-stage build where an intermediate "build" image with all the tools is used to build the "binaries" which are then copied to a smaller deploy/production image without all the tools. One way of archiving this in `python` is using a virtual environment. The process is outlined [here](https://pythonspeed.com/articles/multi-stage-docker-python/), [here](https://blog.devgenius.io/building-smaller-docker-images-the-right-way-1b6c12c112e1) and [here](https://gabnotes.org/lighten-your-python-image-docker-multi-stage-builds/).

After switching to a multi-stage build, the final image size is **~100 MB**, with a comparable build time on my Rockpi4b (170sec vs 180sec)