### PR TITLE
Install wheel before python packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN set -xe \
                           py-pip          \
                           rust            \
     && python3 -m venv --copies /opt/venv \
+    && python3 -m pip install --upgrade pip wheel \
     && python3 -m pip install appdirs   \
                               chump     \
                               cssselect \


### PR DESCRIPTION
We use `pip` to install the necessary packages to build `urlwatch`

Most of the required packages don't have  pre-packed binary ("wheels"), so they need to be compiled during installation. For two (`minidb` and `urlwatch`) a warning is thrown that the `wheel` package is missing and a legacy method is choose.

```
Using legacy 'setup.py install' for minidb, since package 'wheel' is not installed.
Using legacy 'setup.py install' for urlwatch, since package 'wheel' is not installed.

  Running setup.py install for minidb: started
  Running setup.py install for minidb: finished with status 'done'
  Running setup.py install for urlwatch: started
  Running setup.py install for urlwatch: finished with status 'done'

```

This PR fixes the issue by install `wheel` before all other packages. It would be easy to add `wheel` to the already existing `pip` call, however, this does not work as `wheel` is not used when installed at the same time. 

Therefore, we need a two-step approach.

___

`pip` also warns that it's out-to-date, so I set `pip` to update itself.

```
[notice] A new release of pip available: 22.2.2 -> 22.3.1
[notice] To update, run: pip install --upgrade pip
```
___

Final relevant output
```
Collecting pip
  Downloading pip-22.3.1-py3-none-any.whl (2.1 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2.1/2.1 MB 5.9 MB/s eta 0:00:00
Collecting wheel
  Downloading wheel-0.38.4-py3-none-any.whl (36 kB)
Installing collected packages: wheel, pip
  Attempting uninstall: pip
    Found existing installation: pip 22.2.2
    Uninstalling pip-22.2.2:
      Successfully uninstalled pip-22.2.2
Successfully installed pip-22.3.1 wheel-0.38.4


Building wheels for collected packages: minidb, pyyaml, urlwatch
  Building wheel for minidb (setup.py): started
  Building wheel for minidb (setup.py): finished with status 'done'
  Created wheel for minidb: filename=minidb-2.0.7-py3-none-any.whl size=8927 sha256=cb291cadc7a2bbe326c07b3a015e9e2d5a4765355659a9396e8ae41232de5a2f
  Stored in directory: /root/.cache/pip/wheels/f0/c9/7b/e70ab45c73cbd8698465fb1324bb0b9c796d064aa7487d28c7
  Building wheel for pyyaml (pyproject.toml): started
  Building wheel for pyyaml (pyproject.toml): finished with status 'done'
  Created wheel for pyyaml: filename=PyYAML-6.0-cp310-cp310-linux_x86_64.whl size=45330 sha256=7b1248bdb80c670b517450fc8b9186818da76a90405cdbd8094c07526a54c7ea
  Stored in directory: /root/.cache/pip/wheels/06/72/f6/3f89f64cf1943a82e42cdd8e59d7b2aa98769fd48b08019fc7
  Building wheel for urlwatch (setup.py): started
  Building wheel for urlwatch (setup.py): finished with status 'done'
  Created wheel for urlwatch: filename=urlwatch-2.25-py3-none-any.whl size=94392 sha256=49afbbe747bd3c80dd0b6c7dc9a559cae610d7cad84bf395ab55d04b7fa295d0
  Stored in directory: /root/.cache/pip/wheels/e5/f7/58/91f063f701913271f13aa38cb859ec96fd357ab21bf13ab796
Successfully built minidb pyyaml urlwatch

```