### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "10:00"
+  open-pull-requests-limit: 10
+  target-branch: main


### PR DESCRIPTION
I noticed that a lot of your github actions you use in your `ci.yaml` are outdated. To keep up with upstream development, this PR adds `Dependabot` which will take care of your actions. If one is out-of-date, it will create a PR to automatically update it.