### PR TITLE
Give the container a nicer name

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ networks:
 services:
   urlwatch:
     image: ghcr.io/mjaschen/urlwatch
+    container_name: urlwatch
     volumes:
       - ./data:/data/urlwatch
       - /etc/localtime:/etc/localtime:ro


### PR DESCRIPTION
When the service is started via `docker compose` the container is named `urlwatch-docker-urlwatch-1`. This PR sets the container name fixed to `urlwatch`

https://docs.docker.com/compose/compose-file/compose-file-v3/#container_name