### PR TITLE
Use fixed version base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine as builder
+FROM alpine:3.17 as builder
 
 ENV PATH="/opt/venv/bin:${PATH}"
 
@@ -29,7 +29,7 @@ RUN set -xe \
                               requests  \
                               urlwatch
 
-FROM python:3.10-alpine as deploy
+FROM python:3.10-alpine3.17 as deploy
 
 ENV APP_USER urlwatch
 


### PR DESCRIPTION
Instead of using non-specific base images (which will default to `latest`) use specific versions. If the base image changes (e.g. new alpine images is set as `latest`) build may break unexpectedly. 
Having fixed versions allows to update and test manually and fix potential errors