### PR TITLE
Don't run 'root' cronjobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,4 +50,6 @@ WORKDIR /data/urlwatch
 COPY crontab /var/spool/cron/crontabs/$APP_USER
 RUN chmod 0600 /var/spool/cron/crontabs/$APP_USER
 
+RUN rm /var/spool/cron/crontabs/root
+
 CMD ["crond", "-f", "-l", "6", "-L", "/dev/stdout"]


### PR DESCRIPTION
This PR reduces the logspam occurring because cron also triggers  the `root` cronjobs. Log output looks like

```
urlwatch  | crond: USER root pid 1584 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1585 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1586 cmd run-parts /etc/periodic/hourly
urlwatch  | crond: USER root pid 1587 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1588 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1589 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1590 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1591 cmd run-parts /etc/periodic/hourly
urlwatch  | crond: USER root pid 1592 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1593 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1594 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1595 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1596 cmd run-parts /etc/periodic/hourly
urlwatch  | crond: USER root pid 1597 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1598 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1599 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1600 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1601 cmd run-parts /etc/periodic/hourly
urlwatch  | crond: USER root pid 1602 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1603 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1604 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1605 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1606 cmd run-parts /etc/periodic/hourly
urlwatch  | crond: USER root pid 1607 cmd run-parts /etc/periodic/15min
urlwatch  | crond: USER root pid 1608 cmd run-parts /etc/periodic/15min
```

However, on the container there are no periodic jobs defined for `root`

```
data/urlwatch # ls -lha /etc/periodic/15min/
total 8K     
drwxr-xr-x    2 root     root        4.0K Feb 10 17:45 .
drwxr-xr-x    7 root     root        4.0K Feb 10 17:45 ..
/data/urlwatch # ls -lha /etc/periodic/daily/
total 8K     
drwxr-xr-x    2 root     root        4.0K Feb 10 17:45 .
drwxr-xr-x    7 root     root        4.0K Feb 10 17:45 ..
/data/urlwatch # ls -lha /etc/periodic/hourly/
total 8K     
drwxr-xr-x    2 root     root        4.0K Feb 10 17:45 .
drwxr-xr-x    7 root     root        4.0K Feb 10 17:45 ..
/data/urlwatch # ls -lha /etc/periodic/monthly/
total 8K     
drwxr-xr-x    2 root     root        4.0K Feb 10 17:45 .
drwxr-xr-x    7 root     root        4.0K Feb 10 17:45 ..
/data/urlwatch # ls -lha /etc/periodic/weekly/
total 8K     
drwxr-xr-x    2 root     root        4.0K Feb 10 17:45 .
drwxr-xr-x    7 root     root        4.0K Feb 10 17:45 ..

```

Solution is simply deleting the root contab file.