### PR TITLE
Use PyInstaller to create a urlwatch executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,40 @@
-FROM alpine:3.17 as builder
+FROM python:3.11.3-alpine3.18 as builder
 
-ENV PATH="/opt/venv/bin:${PATH}"
+RUN apk add --no-cache \
+    binutils \
+    git \
+    upx                 
 
-RUN set -xe \
-    && apk add --no-cache ca-certificates \
-                          build-base      \
-                          cargo           \
-                          libffi-dev      \
-                          libxml2         \
-                          libxml2-dev     \
-                          libxslt         \
-                          libxslt-dev     \
-                          openssl-dev     \
-                          python3         \
-                          python3-dev     \
-                          py-pip          \
-                          rust            \
-    && python3 -m venv --copies /opt/venv \
-    && python3 -m pip install --upgrade pip wheel \
-    && python3 -m pip install appdirs   \
-                              chump     \
-                              cssselect \
-                              html2text \
-                              keyring   \
-                              lxml      \
-                              minidb    \
-                              pyyaml    \
-                              requests  \
-                              urlwatch
+# Update pip, wheel and setuptools, install pyinstaller
+RUN python3 -m pip install --upgrade pip wheel setuptools \
+    && python3 -m pip install pyinstaller
 
-FROM python:3.10-alpine3.17 as deploy
+# Get latest urlwatch source
+RUN git clone https://github.com/thp/urlwatch.git
+WORKDIR /urlwatch
 
+# Install requirements and urlwatch from source
+RUN python3 -m pip install -r requirements.txt \
+    && python3 -m pip install .
+
+# Install additional packages used by urlwatch (optional)
+# see https://urlwatch.readthedocs.io/en/latest/dependencies.html#optional-packages
+RUN python3 -m pip install \
+    chump \
+    html2text
+
+# Build the executable file (-F) and strip debug symbols 
+# Use pythons optimize flag (-OO) to remove doc strings, assert statements, sets __debug__ to false
+RUN python3 -OO -m PyInstaller -F --strip urlwatch 
+
+# Debug: list warnings
+# RUN cat build/urlwatch/warn-urlwatch.txt
+
+
+FROM alpine:3.18 as deploy
 ENV APP_USER urlwatch
 
-COPY --from=builder /opt/venv /opt/venv
-ENV PATH="/opt/venv/bin:${PATH}"
+COPY --from=builder /urlwatch/dist/urlwatch /usr/local/bin/urlwatch
 
 RUN addgroup $APP_USER
 RUN adduser -D -G $APP_USER $APP_USER
@@ -45,9 +45,9 @@ RUN mkdir -p /data/urlwatch \
 
 VOLUME /data/urlwatch
 
+RUN rm /var/spool/cron/crontabs/root
+
 COPY crontabfile ./crontabfile
 COPY run.sh ./run.sh
-
-RUN rm /var/spool/cron/crontabs/root
 
 CMD ["/bin/sh", "run.sh"]


### PR DESCRIPTION
So far, the image installed `urlwatch` and all necessary files in an virtual environment which was copied from the builder to the deploy stage. This still required a `python` based image as base for the deploy stage. 

This PR uses another approach: `urlwatch` is installed from source, optional packages are installed and the whole thing is bundled with `PyInstaller` ([here](https://pyinstaller.org/en/stable/index.html)) into a single executable file. 
This file is self-contained to run `urlwatch`, so a bare `Alpine` image is sufficient. 

This brings down the whole image to ~26MB

Side note: this PR updates the Alpine version to 3.18 as well

Idea from https://medium.com/analytics-vidhya/dockerizing-a-rest-api-in-python-less-than-9-mb-and-based-on-scratch-image-ef0ee3ad3f0a