### PR TITLE
Don't send cron output to /dev/stout

### DIFF
--- a/crontabfile
+++ b/crontabfile
@@ -1,2 +1,2 @@
-*/15 * * * * cd /data/urlwatch && urlwatch --verbose --urls urls.yaml --config urlwatch.yaml --hooks hooks.py --cache cache.db
+*/15 * * * * date && echo "Running urlwatch" && cd /data/urlwatch && urlwatch --verbose --urls urls.yaml --config urlwatch.yaml --hooks hooks.py --cache cache.db
 

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
 crontab -u $APP_USER ./crontabfile
-crond -f -l 6 -L /dev/stdout
+crond -f -l 6


### PR DESCRIPTION
Currently, the output of `crond` itself is send to `/dev/stout` creating (uninformative) logspam.
This PR removes the logging to `stout` but enhances the example crontab file to output the current date/time and what is being executed.

Old

```
urlwatch  | crond: crond (busybox 1.36.0) started, log level 6
urlwatch  | crond: USER urlwatch pid   9 cmd cd /data/urlwatch && urlwatch --config urlwatch.yaml --urls urls.yaml  --cache cache.db --hooks hooks.py
urlwatch  | crond: USER urlwatch pid  28 cmd cd /data/urlwatch && urlwatch --config urlwatch.yaml --urls urls.yaml  --cache cache.db --hooks hooks.py
urlwatch  | crond: USER urlwatch pid  47 cmd cd /data/urlwatch && urlwatch --config urlwatch.yaml --urls urls.yaml  --cache cache.db --hooks hooks.py
urlwatch  | crond: USER urlwatch pid  66 cmd cd /data/urlwatch && urlwatch --config urlwatch.yaml --urls urls.yaml  --cache cache.db --hooks hooks.py
urlwatch  | crond: USER urlwatch pid  85 cmd cd /data/urlwatch && urlwatch --config urlwatch.yaml --urls urls.yaml  --cache cache.db --hooks hooks.py
urlwatch  | crond: USER urlwatch pid 104 cmd cd /data/urlwatch && urlwatch --config urlwatch.yaml --urls urls.yaml  --cache cache.db --hooks hooks.py
urlwatch  | crond: USER urlwatch pid 123 cmd cd /data/urlwatch && urlwatch --config urlwatch.yaml --urls urls.yaml  --cache cache.db --hooks hooks.py
```

New

```
urlwatch  | Thu May 17 16:00:00 CEST 2023
urlwatch  | Running urlwatch
urlwatch  | Thu May 18 20:00:00 CEST 2023
urlwatch  | Running urlwatch
urlwatch  | Thu May 18 00:00:00 CEST 2023
urlwatch  | Running urlwatch
urlwatch  | ===========================================================================
urlwatch  | 01. CHANGED: Fritz Labor
urlwatch  | 02. CHANGED: Pixel6a Update Tracker
....

urlwatch  | Thu May 18 04:00:00 CEST 2023
urlwatch  | Running urlwatch
urlwatch  | Thu May 18 08:00:00 CEST 2023
urlwatch  | Running urlwatch

```