### PR TITLE
Python 3.11 -> 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.3-alpine3.18 as builder
+FROM python:3.13.6-alpine3.22 AS builder
 
 RUN apk add --no-cache \
     binutils \
@@ -38,8 +38,8 @@ RUN python3 -OO -m PyInstaller -F --strip urlwatch
 # RUN cat build/urlwatch/warn-urlwatch.txt
 
 
-FROM alpine:3.18 as deploy
-ENV APP_USER urlwatch
+FROM alpine:3.22 AS deploy
+ENV APP_USER=urlwatch
 
 COPY --from=builder /urlwatch/dist/urlwatch /usr/local/bin/urlwatch
 
@@ -47,8 +47,8 @@ RUN addgroup $APP_USER
 RUN adduser --disabled-password --ingroup $APP_USER $APP_USER
 
 RUN mkdir -p /data/urlwatch \
-  && chown -R $APP_USER:$APP_USER /data/urlwatch \
-  && chmod 0755 /data/urlwatch
+    && chown -R $APP_USER:$APP_USER /data/urlwatch \
+    && chmod 0755 /data/urlwatch
 
 VOLUME /data/urlwatch
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,13 @@
-version: '3'
-
 networks:
     urlwatch:
 
 services:
-  urlwatch:
-    image: ghcr.io/mjaschen/urlwatch
-    container_name: urlwatch
-    volumes:
-      - ./data:/data/urlwatch
-      - /etc/localtime:/etc/localtime:ro
-    restart: "unless-stopped"
-    networks:
-      - urlwatch
+    urlwatch:
+        image: ghcr.io/mjaschen/urlwatch
+        container_name: urlwatch
+        volumes:
+            - ./data:/data/urlwatch
+            - /etc/localtime:/etc/localtime:ro
+        restart: "unless-stopped"
+        networks:
+            - urlwatch

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 
-crontab -u $APP_USER ./crontabfile
+crontab -u "$APP_USER" ./crontabfile
 crond -f -l 6


### PR DESCRIPTION
- build with python:3.13.6-alpine3.22
- run with alpine:3.22
- remove `version` from Docker Compose config 